### PR TITLE
Support Python {3.9, 3.10}

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,16 +54,17 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.11
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.11'
-    - name: Build and test (3.11)
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
+    # TODO Restore when qulacs 3.11 wheels are available.
+    # - name: Set up Python 3.11
+    #   if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+    #   uses: actions/setup-python@v4
+    #   with:
+    #     python-version: '3.11'
+    # - name: Build and test (3.11)
+    #   if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+    #   shell: bash
+    #   run: |
+    #     ./.github/workflows/build-test nomypy
     - uses: actions/upload-artifact@v3
       if: github.event_name == 'release' || contains(github.ref, 'refs/heads/wheel')
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,21 +30,21 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
-    - name: Build and test (3.8)
+        python-version: '3.9'
+    - name: Build and test (3.9)
       if: github.event_name == 'push' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
-    - name: Build and test including remote checks (3.9) mypy
+        python-version: '3.10'
+    - name: Build and test including remote checks (3.10) mypy
       if:  (matrix.os == 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       shell: bash
       run: |
@@ -54,12 +54,12 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
-    - name: Build and test (3.10)
+        python-version: '3.11'
+    - name: Build and test (3.11)
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       shell: bash
       run: |
@@ -110,10 +110,10 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Download all wheels
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
       shell: bash
       run: |
         ./.github/workflows/build-test mypy
-    - name: Build and test including remote checks (3.9) nomypy
+    - name: Build and test including remote checks (3.10) nomypy
       if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,15 +13,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Upgrade pip and install wheel
       run: pip install --upgrade pip wheel
     - name: Install pytket qulacs
-      run: |        
-        pip install .
+      run: pip install .
     - name: Install docs dependencies
       run: |
         pip install -r .github/workflows/docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ run on the Qulacs simulator.
 
 ## Getting started
 
-`pytket-qulacs` is available for Python 3.8, 3.9 and 3.10, on Linux, MacOS
+`pytket-qulacs` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
 and Windows. To install, run:
 
 ```pip install pytket-qulacs```

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ run on the Qulacs simulator.
 
 ## Getting started
 
-`pytket-qulacs` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
-and Windows. To install, run:
+`pytket-qulacs` is available for Python 3.9 and 3.10, on Linux, MacOS and
+Windows. To install, run:
 
 ```pip install pytket-qulacs```
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Drop support for Python 3.8; add support for 3.11.
+
 0.25.0 (December 2022)
 ----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-* Drop support for Python 3.8; add support for 3.11.
+* Drop support for Python 3.8.
 
 0.25.0 (December 2022)
 ----------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -20,8 +20,8 @@ circuit simulator.
 ``pytket-qulacs`` is an extension to ``pytket`` that allows ``pytket`` circuits
 to be simulated using ``qulacs``.
 
-``pytket-qulacs`` is available for Python 3.8 and 3.9 on Linux, MacOS and
-Windows, and also for Python 3.10 on Linux. To install, run:
+``pytket-qulacs`` is available for Python 3.9, 3.10 and 3.11 on Linux, MacOS and
+Windows. To install, run:
 
 ::
    

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -20,7 +20,7 @@ circuit simulator.
 ``pytket-qulacs`` is an extension to ``pytket`` that allows ``pytket`` circuits
 to be simulated using ``qulacs``.
 
-``pytket-qulacs`` is available for Python 3.9, 3.10 and 3.11 on Linux, MacOS and
+``pytket-qulacs`` is available for Python 3.9 and 3.10 on Linux, MacOS and
 Windows. To install, run:
 
 ::

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.9
 warn_unused_configs = True
 
 disallow_untyped_decorators = False

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket == 1.11.0rc0", "qulacs ~= 0.5.0"],
+    install_requires=["pytket ~= 1.9", "qulacs ~= 0.5.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     project_urls={
         "Documentation": "https://cqcl.github.io/pytket-qulacs/api/index.html",
         "Source": "https://github.com/CQCL/pytket-qulacs",
@@ -45,9 +45,9 @@ setup(
     install_requires=["pytket ~= 1.9", "qulacs ~= 0.5.0"],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     license="Apache 2",
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
-    install_requires=["pytket ~= 1.9", "qulacs ~= 0.5.0"],
+    install_requires=["pytket == 1.11.0rc0", "qulacs ~= 0.5.0"],
     classifiers=[
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "Environment :: Console",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
+        # "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
We can't support 3.11 until qulacs wheels are released (attempting to build qulacs on the CI fails because of all the prerequisites, like boost).

https://github.com/CQCL/pytket-qulacs/issues/23

So just support 3.9 and 3.10 for now.