### PR TITLE
Add support for multi-register circuit conversion

### DIFF
--- a/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -291,7 +291,7 @@ class QulacsBackend(Backend):
             self._check_all_circuits([state_circuit], nomeasure_warn=False)
 
         observable = Observable(state_circuit.n_qubits)
-        for (qps, coeff) in operator._dict.items():
+        for qps, coeff in operator._dict.items():
             _items = []
             if qps != QubitPauliString():
                 for qubit, pauli in qps.map.items():

--- a/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -55,7 +55,6 @@ from pytket.predicates import (
 from pytket.circuit import Pauli
 from pytket.passes import auto_rebase_pass
 from pytket.pauli import QubitPauliString
-from pytket.architecture import Architecture
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.outcomearray import OutcomeArray
 from pytket.extensions.qulacs.qulacs_convert import (

--- a/pytket/extensions/qulacs/qulacs_convert.py
+++ b/pytket/extensions/qulacs/qulacs_convert.py
@@ -108,7 +108,7 @@ def tk_to_qulacs(
     circ = circuit.copy()
     if replace_implicit_swaps:
         circ.replace_implicit_wire_swaps()
-        qulacs_circ = QuantumCircuit(circ.n_qubits)
+    qulacs_circ = QuantumCircuit(circ.n_qubits)
 
     # Dictionary mapping qubits to their absolute position
     # Within the quantum circuit

--- a/pytket/extensions/qulacs/qulacs_convert.py
+++ b/pytket/extensions/qulacs/qulacs_convert.py
@@ -17,69 +17,7 @@
 import numpy as np
 from qulacs import QuantumCircuit, gate
 from pytket.circuit import Circuit, OpType
-from pytket.unit_id import Qubit
-
-
-def get_register_offset_map(circuit: Circuit) -> dict[str, int]:
-    """Creates a map that accounts for the offset required to access the
-    `pytket._tket.unit_id.Qubit`s of a `pytket._tket.unit_id.QubitRegister`
-    with an absolute index.
-
-    Args:
-        circuit (Circuit): The circuit for which to create the map.
-
-    Returns:
-        dict[str, int]: A dictionary where the keys are the names of the quantum
-            registers of the circuit and the values are
-            the total number of qubits in preceeding registers.
-    """
-    qubits_preceeding = 0
-    offset_dict: dict[str, int] = {}
-
-    for register in circuit.q_registers:
-        # The number of qubits to offset by is the number
-        # Of qubits in all register preceeding this one
-        offset_dict[register.name] = qubits_preceeding
-
-        # Increase the number of qubits
-        # By the number of qubits this register contains
-        qubits_preceeding += register.size
-
-    return offset_dict
-
-
-def get_qubit_index_map(circuit: Circuit, reverse_order: bool) -> dict[Qubit, int]:
-    """Creates a map that contains the absolute position of a qubit in a given circuit,
-    accounting for each qubit's register as well.
-
-    Args:
-        circuit (Circuit): The circuit for which to create the map.
-        reverse_order (bool): Whether the circuits' qubit positions are reversed.
-
-    Returns:
-        dict[Qubit, int]: A dictionary where the keys are the circuit's qubits
-            and the values are the absolute positions of qubits,
-            accounting for the register's position.
-    """
-    # Get the dictionary accounting for register positions
-    offset_map = get_register_offset_map(circuit)
-    index_map: dict[Qubit, int] = {}
-
-    for register in circuit.q_registers:
-        for qubit_index, qubit in enumerate(register.to_list()):
-            # The position of the qubit is the sum of the offset (preceeding qubits)
-            # And the position of the qubit within its register
-            qubit_position = offset_map[register.name] + qubit_index
-
-            # Invert the if the qubits are stored in reverse order
-            index_map[qubit] = (
-                qubit_position
-                if not reverse_order
-                else circuit.n_qubits - 1 - qubit_position
-            )
-
-    return index_map
-
+from pytket.passes import FlattenRegisters
 
 _ONE_QUBIT_GATES = {
     OpType.X: gate.X,
@@ -106,19 +44,22 @@ def tk_to_qulacs(
 ) -> QuantumCircuit:
     """Convert a pytket circuit to a qulacs circuit object."""
     circ = circuit.copy()
+
+    if not circ.is_simple:
+        FlattenRegisters().apply(circ)
+
     if replace_implicit_swaps:
         circ.replace_implicit_wire_swaps()
+    n_qubits = circ.n_qubits
     qulacs_circ = QuantumCircuit(circ.n_qubits)
-
-    # Dictionary mapping qubits to their absolute position
-    # Within the quantum circuit
-    index_map = get_qubit_index_map(circ, reverse_index)
-
+    index_map = {
+        i: (i if not reverse_index else n_qubits - 1 - i) for i in range(n_qubits)
+    }
     for com in circ:
         optype = com.op.type
         if optype in _IBM_GATES:
             qulacs_gate = _IBM_GATES[optype]
-            index = index_map[com.qubits[0]]
+            index = index_map[com.qubits[0].index[0]]
 
             if optype == OpType.U1:
                 param = com.op.params[0]
@@ -134,19 +75,19 @@ def tk_to_qulacs(
 
         elif optype in _ONE_QUBIT_GATES:
             qulacs_gate = _ONE_QUBIT_GATES[optype]
-            index = index_map[com.qubits[0]]
+            index = index_map[com.qubits[0].index[0]]
             add_gate = qulacs_gate(index)
 
         elif optype in _ONE_QUBIT_ROTATIONS:
             qulacs_gate = _ONE_QUBIT_ROTATIONS[optype]
-            index = index_map[com.qubits[0]]
+            index = index_map[com.qubits[0].index[0]]
             param = com.op.params[0] * np.pi
             add_gate = qulacs_gate(index, -param)  # parameter negated for qulacs
 
         elif optype in _TWO_QUBIT_GATES:
             qulacs_gate = _TWO_QUBIT_GATES[optype]
-            id1 = index_map[com.qubits[0]]
-            id2 = index_map[com.qubits[1]]
+            id1 = index_map[com.qubits[0].index[0]]
+            id2 = index_map[com.qubits[1].index[0]]
             add_gate = qulacs_gate(id1, id2)
 
         elif optype in _MEASURE_GATES:

--- a/pytket/extensions/qulacs/qulacs_convert.py
+++ b/pytket/extensions/qulacs/qulacs_convert.py
@@ -17,6 +17,60 @@
 import numpy as np
 from qulacs import QuantumCircuit, gate
 from pytket.circuit import Circuit, OpType
+from pytket.unit_id import Qubit
+
+def get_register_offset_map(circuit: Circuit) -> dict[str, int]:
+    """Creates a map that accounts for the offset required to access the
+    `pytket._tket.unit_id.Qubit`s of a `pytket._tket.unit_id.QubitRegister`
+    with an absolute index.
+
+    Args:
+        circuit (Circuit): The circuit for which to create the map.
+
+    Returns:
+        dict[str, int]: A dictionary where the keys are the names of the quantum registers
+            of the circuit and the values are the total number of qubits in preceeding registers.
+    """
+    qubits_preceeding = 0
+    offset_dict: dict[str, int] = {}
+    
+    for register in circuit.q_registers:
+        # The number of qubits to offset by is the number
+        # Of qubits in all register preceeding this one
+        offset_dict[register.name] = qubits_preceeding
+        
+        # Increase the number of qubits
+        # By the number of qubits this register contains
+        qubits_preceeding += register.size
+    
+    return offset_dict   
+
+def get_qubit_index_map(circuit: Circuit, reverse_order: bool) -> dict[Qubit, int]:
+    """Creates a map that contains the absolute position of a qubit in a given circuit,
+    accounting for each qubit's register as well.
+
+    Args:
+        circuit (Circuit): The circuit for which to create the map.
+        reverse_order (bool): Whether the circuits' qubit positions are reversed.
+
+    Returns:
+        dict[Qubit, int]: A dictionary where the keys are the circuit's qubits
+            and the values are the absolute positions of qubits, accounting for the register's position.
+    """
+    # Get the dictionary accounting for register positions
+    offset_map = get_register_offset_map(circuit)
+    index_map: dict[Qubit, int] = {}
+    
+    for register in circuit.q_registers:
+        for qubit_index, qubit in enumerate(register.to_list()):
+            # The position of the qubit is the sum of the offset (preceeding qubits)
+            # And the position of the qubit within its register
+            qubit_position = offset_map[register.name] + qubit_index
+            
+            # Invert the if the qubits are stored in reverse order
+            index_map[qubit] = qubit_position if not reverse_order else circuit.n_qubits - 1 - qubit_position
+            
+    return index_map
 
 _ONE_QUBIT_GATES = {
     OpType.X: gate.X,
@@ -47,14 +101,17 @@ def tk_to_qulacs(
         circ.replace_implicit_wire_swaps()
     n_qubits = circ.n_qubits
     qulacs_circ = QuantumCircuit(circ.n_qubits)
-    index_map = {
-        i: (i if not reverse_index else n_qubits - 1 - i) for i in range(n_qubits)
-    }
+    
+    # Dictionary mapping qubits to their absolute position
+    # Within the quantum circuit
+    index_map = get_qubit_index_map(circ, reverse_index)
+    
     for com in circ:
         optype = com.op.type
         if optype in _IBM_GATES:
             qulacs_gate = _IBM_GATES[optype]
-            index = index_map[com.qubits[0].index[0]]
+            
+            index = index_map[com.qubits[0]]
 
             if optype == OpType.U1:
                 param = com.op.params[0]
@@ -70,19 +127,19 @@ def tk_to_qulacs(
 
         elif optype in _ONE_QUBIT_GATES:
             qulacs_gate = _ONE_QUBIT_GATES[optype]
-            index = index_map[com.qubits[0].index[0]]
+            index = index_map[com.qubits[0]]
             add_gate = qulacs_gate(index)
 
         elif optype in _ONE_QUBIT_ROTATIONS:
             qulacs_gate = _ONE_QUBIT_ROTATIONS[optype]
-            index = index_map[com.qubits[0].index[0]]
+            index = index_map[com.qubits[0]]
             param = com.op.params[0] * np.pi
             add_gate = qulacs_gate(index, -param)  # parameter negated for qulacs
 
         elif optype in _TWO_QUBIT_GATES:
             qulacs_gate = _TWO_QUBIT_GATES[optype]
-            id1 = index_map[com.qubits[0].index[0]]
-            id2 = index_map[com.qubits[1].index[0]]
+            id1 = index_map[com.qubits[0]]
+            id2 = index_map[com.qubits[1]]
             add_gate = qulacs_gate(id1, id2)
 
         elif optype in _MEASURE_GATES:

--- a/pytket/extensions/qulacs/qulacs_convert.py
+++ b/pytket/extensions/qulacs/qulacs_convert.py
@@ -29,8 +29,9 @@ def get_register_offset_map(circuit: Circuit) -> dict[str, int]:
         circuit (Circuit): The circuit for which to create the map.
 
     Returns:
-        dict[str, int]: A dictionary where the keys are the names of the quantum registers
-            of the circuit and the values are the total number of qubits in preceeding registers.
+        dict[str, int]: A dictionary where the keys are the names of the quantum
+            registers of the circuit and the values are
+            the total number of qubits in preceeding registers.
     """
     qubits_preceeding = 0
     offset_dict: dict[str, int] = {}
@@ -57,7 +58,8 @@ def get_qubit_index_map(circuit: Circuit, reverse_order: bool) -> dict[Qubit, in
 
     Returns:
         dict[Qubit, int]: A dictionary where the keys are the circuit's qubits
-            and the values are the absolute positions of qubits, accounting for the register's position.
+            and the values are the absolute positions of qubits,
+            accounting for the register's position.
     """
     # Get the dictionary accounting for register positions
     offset_map = get_register_offset_map(circuit)
@@ -106,8 +108,7 @@ def tk_to_qulacs(
     circ = circuit.copy()
     if replace_implicit_swaps:
         circ.replace_implicit_wire_swaps()
-    n_qubits = circ.n_qubits
-    qulacs_circ = QuantumCircuit(circ.n_qubits)
+        qulacs_circ = QuantumCircuit(circ.n_qubits)
 
     # Dictionary mapping qubits to their absolute position
     # Within the quantum circuit


### PR DESCRIPTION
# Description

Currently, the `tk_to_qulacs` function converts the indices of the qubits upon gates operate in an _absolute_ manner, i.e., retrieve the qubit's index from its register. For example, for two qubit gates:

```python
  id1 = index_map[com.qubits[0].index[0]]
  id2 = index_map[com.qubits[1].index[0]]
```

As a result, circuits with multiple registers are not converted correctly. The corresponding Qulacs circuit that the function builds only has a single register, and `index_map` does not account for the register's position in the original tket circuit. I added two functions that build a dictionary in such a way that multiple registers are accounted for in the input circuit.
