### PR TITLE
Fix incorrect readout when circuit contains implicit swaps

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Fix incorrect readout when circuit contains implicit swaps 
+
 0.35.0 (March 2024)
 -------------------
 

--- a/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -218,8 +218,12 @@ class QulacsBackend(Backend):
             shots = None
             bits = None
             if n_shots_circ is not None:
+                # tk_to_qulacs might add SWAPs after measurements,
+                # hence we need to push the measurements through the
+                # SWAPs.
+                wire_map = circuit.implicit_qubit_permutation()
                 bits2index = list(
-                    (com.bits[0], qubits.index(com.qubits[0]))
+                    (com.bits[0], qubits.index(wire_map[com.qubits[0]]))
                     for com in circuit
                     if com.op.type == OpType.Measure
                 )


### PR DESCRIPTION
# Description

When converting a tket circuit to a qulacs circuit, we replace implicit swaps with SWAP gates so we don't have to permute the statevector after the simulation. However, when sampling the statevector to give measurement readouts, we must also change the args in the Measure commands to account for the added SWAPs.

# Related issues

fixes #86 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
