### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -76,7 +76,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,4 +2,13 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.qulacs
-    :members: tk_to_qulacs, QulacsBackend
+.. automodule:: pytket.extensions.qulacs._metadata
+.. automodule:: pytket.extensions.qulacs.qulacs_convert
+
+    .. autofunction:: tk_to_qulacs
+
+.. automodule:: pytket.extensions.qulacs.backends
+.. automodule:: pytket.extensions.qulacs.backends.qulacs_backend
+
+    .. autoclass:: QulacsBackend
+        :members:

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,7 +46,7 @@ Changelog
 ---------------------
 
 * Updated pytket version requirement to 1.23.
-* Backends now report backend_info.
+* Backends now report :py:attr:`~pytket.backends.backend.Backend.backend_info`.
 
 0.32.0 (November 2023)
 ----------------------
@@ -62,7 +62,7 @@ Changelog
 0.30.0 (September 2023)
 -----------------------
 
-* Allow setting of rng seed in qulacs backend.
+* Allow setting of rng seed in :py:class:`QulacsBackend`.
 * Updated pytket version requirement to 1.19.
 
 0.29.0 (June 2023)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Afterwards, install ``qulacs-gpu``:
    
    pip install qulacs-gpu
 
-The ``QulacsGPUBackend`` has an identical API to the ``QulacsBackend``.
+The ``QulacsGPUBackend`` has an identical API to the :py:class:`~.QulacsBackend`.
 
 .. toctree::
     api.rst

--- a/pytket/extensions/qulacs/__init__.py
+++ b/pytket/extensions/qulacs/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for conversion from tket primitives to Qulacs primitives."""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__

--- a/pytket/extensions/qulacs/backends/__init__.py
+++ b/pytket/extensions/qulacs/backends/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backend for utilising the Qulacs simulator directly from pytket"""
 
 import warnings
 

--- a/pytket/extensions/qulacs/backends/qulacs_backend.py
+++ b/pytket/extensions/qulacs/backends/qulacs_backend.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Methods to allow tket circuits to be ran on the Qulacs simulator"""
-
 from collections.abc import Sequence
 from logging import warning
 from random import Random

--- a/pytket/extensions/qulacs/qulacs_convert.py
+++ b/pytket/extensions/qulacs/qulacs_convert.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Conversion from to tket circuits to Qulacs circuits"""
-
 import numpy as np
 
 from pytket.circuit import Circuit, OpType


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
